### PR TITLE
Improve record printing

### DIFF
--- a/ppx_debug/ppx_debug_printing.ml
+++ b/ppx_debug/ppx_debug_printing.ml
@@ -456,7 +456,7 @@ module Printer = struct
   let record ~unboxed fields fmt value =
     let value : 'a array = Obj.magic value in
 
-    fprintf fmt "{ ";
+    fprintf fmt "@[<v 0>@ {@;<0 2>@[<v 0>";
     let rec loop i l =
       match l with
       | [] -> ()
@@ -468,8 +468,8 @@ module Printer = struct
             Array.get value i in
         fprintf fmt "%s = %a" name print field;
         (match tl with
-        | [] -> fprintf fmt " }"
-        | _ -> fprintf fmt "; ");
+        | [] -> fprintf fmt "@]@;}@]"
+        | _ -> fprintf fmt ";@;");
         loop (i + 1) tl in
     loop 0 fields
 


### PR DESCRIPTION
Before:

```ocaml
{ id = "<abstract:Dune__exe__Device.Id.t>"; uid = "AppleUSBAudioEngine:LOUD Technologies Inc.:ProFX:1113000:1,2"; name = "ProFX"; manufacturer = "LOUD Technologies Inc." }
```

After: 

```ocaml
{
  id = "<abstract:Dune__exe__Device.Id.t>";
  uid = "AppleUSBAudioEngine:LOUD Technologies Inc.:ProFX:1113000:1,2";
  name = "ProFX";
  manufacturer = "LOUD Technologies Inc."
}
```

